### PR TITLE
Agregado de parámetro para especificar versión y checkout a develop

### DIFF
--- a/update-and-push/update-and-push.env.example
+++ b/update-and-push/update-and-push.env.example
@@ -38,12 +38,14 @@ export GITHUB_SERVER="git@github.com:ong-bitcoin-argentina/DIDI-SSI-Server.git";
 
 #2.1. General
 
-export DOK_AZ_NAME="<CHANGE_ME>";  #Nombre del repo ACR.
-export DOK_AZ_USER="<CHANGE_ME>""; #Usuario para ingresar al ACR.
-export DOK_AZ_PASW="<CHANGE_ME>""; #Password para ingresar al ACR.
-DOK_AZ_REPO="<CHANGE_ME>"";
+export DOK_AZ_NAME="<CHANGE_ME>"; #Nombre del repo ACR.
+export DOK_AZ_USER="<CHANGE_ME>"; #Usuario para ingresar al ACR.
+export DOK_AZ_PASW="<CHANGE_ME>"; #Password para ingresar al ACR.
+DOK_AZ_REPO="<CHANGE_ME>";		  #Repositorio Docker.
 
-DOK_VERSION="<CHANGE_ME>"";		   #Cambiar de acuerdo a la versión que se vaya a buildear.
+if [ "$DOK_VERSION" == "" ]; then
+	DOK_VERSION="<CHANGE_ME>";	  #Cambiar de acuerdo a la versión que se vaya a buildear (no puede comenzar con "-").
+fi
 
 #2.2. Docker Files (módulos de DIDI/Semillas)
 


### PR DESCRIPTION
Ya está Mati. Ahora siempre hace checkout a develop y se puede especificar la versión por parámetro.